### PR TITLE
Add `URL` and `BugReports` fields to `DESCRIPTION`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,8 @@ Authors@R: c(
 Description: These guidelines are meant to provide a pragmatic, yet rigorous, help to drug developers and decision makers, since they are shaped by three fundamental ingredients: the clinically determined margin of detriment on OS that is unacceptably high (delta null); the benefit on OS that is plausible given the mechanism of action of the novel intervention (delta alt); and the quantity of information (i.e. survival events) it is feasible to accrue given the clinical and drug development setting. The proposed guidelines facilitate transparent discussions between stakeholders focusing on the risks of erroneous decisions and what might be an acceptable trade-off between power and the false positive error rate. 
 License: GPL (>= 3)
 Maintainer: Thibaud Coroller <thibaud.coroller@novartis.com>
+URL: https://opensource.nibr.com/monitOS/, https://github.com/Novartis/monitOS
+BugReports: https://github.com/Novartis/monitOS/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3


### PR DESCRIPTION
This PR adds two fields `URL` and `BugReports` to the `DESCRIPTION` file, so that users can find the source repo and documentation easily. These are also important metadata for the riskmetric package to quantify the robustness of packages.

They will look like this:

## CRAN

<img width="600" alt="cran" src="https://github.com/Novartis/monitOS/assets/199363/145f2e12-7b42-4226-8c9d-ea2e94e37b54">

## pkgdown

<img width="600" alt="pkgdown" src="https://github.com/Novartis/monitOS/assets/199363/05f84092-bbad-4a62-9985-f9620265ec2f">